### PR TITLE
実装機能１：Home画面のお知らせ一覧を降順で5件表示する (PORTAL-39)　実装機能２：お知らせを通常と重要に出し分けを行い、表示する (PORTAL-40)

### DIFF
--- a/ShainKintaiKanri/src/main/java/jp/co/bss/kintai/controller/HomeController.java
+++ b/ShainKintaiKanri/src/main/java/jp/co/bss/kintai/controller/HomeController.java
@@ -16,34 +16,35 @@ import jp.co.bss.kintai.service.HomeService;
 
 @Controller
 public class HomeController {
-	
+
 	@Autowired
 	private HomeService homeService;
- 
-    @GetMapping("/home")
-    public String home(HttpSession session, Model model) {
-    	List<HomeInfo> notificationsData = homeService.getNotificationTitleInfoList();
-    	
-    	// 通常のお知らせと重要なお知らせを区別して抽出
-        List<HomeInfo> normalNotifications = new ArrayList<>();
-        List<HomeInfo> importantNotifications = new ArrayList<>();
-        for (HomeInfo notificationTitle : notificationsData) {
-            if ("1".equals(notificationTitle.getStatus())) {  // ステータスが1の場合は通常のお知らせ
-                normalNotifications.add(notificationTitle);
-            } else if ("0".equals(notificationTitle.getStatus())) {  // ステータスが0の場合は重要なお知らせ
-                importantNotifications.add(notificationTitle);
-            }
-        }
-        
-        // 重要・通常お知らせのデータを降順に並べ替え
-        Collections.reverse(normalNotifications);
-        Collections.reverse(importantNotifications);
 
-        // 通常お知らせの最後から5件分を抽出
-        List<HomeInfo> lastFiveNormalNotificationsTitle = normalNotifications.subList(0, Math.min(5, normalNotifications.size()));
+	@GetMapping("/home")
+	public String home(HttpSession session, Model model) {
+		List<HomeInfo> notificationsData = homeService.getNotificationTitleInfoList();
 
-        model.addAttribute("normalNotificationTitle", lastFiveNormalNotificationsTitle);
-        model.addAttribute("importantNotificationTitle", importantNotifications);
-        return "home";
-    }
+		// 通常のお知らせと重要なお知らせを区別して抽出
+		List<HomeInfo> normalNotifications = new ArrayList<>();
+		List<HomeInfo> importantNotifications = new ArrayList<>();
+		for (HomeInfo notificationTitle : notificationsData) {
+			if ("0".equals(notificationTitle.getStatus())) { 	// ステータス：0の場合は重要なお知らせ
+				importantNotifications.add(notificationTitle);
+			} else { 											// ステータス：その他の場合は通常のお知らせ
+				normalNotifications.add(notificationTitle);
+			}
+		}
+
+		// 重要・通常お知らせのデータを降順に並べ替え
+		Collections.reverse(normalNotifications);
+		Collections.reverse(importantNotifications);
+
+		// 通常お知らせの最後から5件分を抽出
+		List<HomeInfo> lastFiveNormalNotificationsTitle = normalNotifications.subList(0,
+				Math.min(5, normalNotifications.size()));
+
+		model.addAttribute("normalNotificationTitle", lastFiveNormalNotificationsTitle);
+		model.addAttribute("importantNotificationTitle", importantNotifications);
+		return "home";
+	}
 }

--- a/ShainKintaiKanri/src/main/java/jp/co/bss/kintai/controller/HomeController.java
+++ b/ShainKintaiKanri/src/main/java/jp/co/bss/kintai/controller/HomeController.java
@@ -1,5 +1,6 @@
 package jp.co.bss.kintai.controller;
 
+import java.util.Collections;
 import java.util.List;
 
 import javax.servlet.http.HttpSession;
@@ -20,8 +21,15 @@ public class HomeController {
  
     @GetMapping("/home")
     public String home(HttpSession session, Model model) {
-    	List<HomeInfo> data = homeService.getNotificationTitleInfoList();
-		model.addAttribute("notificationTitle", data);
+    	List<HomeInfo> notificationsData = homeService.getNotificationTitleInfoList();
+    	
+        // データを降順に並べ替え
+        Collections.reverse(notificationsData);
+
+        // 最後から5件分を抽出
+        List<HomeInfo> lastFiveData = notificationsData.subList(0, Math.min(5, notificationsData.size()));
+        
+		model.addAttribute("notificationTitle", lastFiveData);
         return "home";
     }
 }

--- a/ShainKintaiKanri/src/main/java/jp/co/bss/kintai/controller/HomeController.java
+++ b/ShainKintaiKanri/src/main/java/jp/co/bss/kintai/controller/HomeController.java
@@ -1,5 +1,6 @@
 package jp.co.bss.kintai.controller;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -23,13 +24,26 @@ public class HomeController {
     public String home(HttpSession session, Model model) {
     	List<HomeInfo> notificationsData = homeService.getNotificationTitleInfoList();
     	
-        // データを降順に並べ替え
-        Collections.reverse(notificationsData);
-
-        // 最後から5件分を抽出
-        List<HomeInfo> lastFiveData = notificationsData.subList(0, Math.min(5, notificationsData.size()));
+    	// 通常のお知らせと重要なお知らせを区別して抽出
+        List<HomeInfo> normalNotifications = new ArrayList<>();
+        List<HomeInfo> importantNotifications = new ArrayList<>();
+        for (HomeInfo notificationTitle : notificationsData) {
+            if ("1".equals(notificationTitle.getStatus())) {  // ステータスが1の場合は通常のお知らせ
+                normalNotifications.add(notificationTitle);
+            } else if ("0".equals(notificationTitle.getStatus())) {  // ステータスが0の場合は重要なお知らせ
+                importantNotifications.add(notificationTitle);
+            }
+        }
         
-		model.addAttribute("notificationTitle", lastFiveData);
+        // 重要・通常お知らせのデータを降順に並べ替え
+        Collections.reverse(normalNotifications);
+        Collections.reverse(importantNotifications);
+
+        // 通常お知らせの最後から5件分を抽出
+        List<HomeInfo> lastFiveNormalNotificationsTitle = normalNotifications.subList(0, Math.min(5, normalNotifications.size()));
+
+        model.addAttribute("normalNotificationTitle", lastFiveNormalNotificationsTitle);
+        model.addAttribute("importantNotificationTitle", importantNotifications);
         return "home";
     }
 }

--- a/ShainKintaiKanri/src/main/java/jp/co/bss/kintai/mapper/HomeInfoMapper.xml
+++ b/ShainKintaiKanri/src/main/java/jp/co/bss/kintai/mapper/HomeInfoMapper.xml
@@ -3,7 +3,7 @@
 <mapper namespace="jp.co.bss.kintai.mapper.HomeInfoMapper">
 
     <select id="getNotificationTitleListInfoByUserName" resultType="jp.co.bss.kintai.model.HomeInfo">
-        SELECT title FROM notifications ;
+        SELECT title, status, creation_date FROM notifications ;
     </select>
 
 </mapper>

--- a/ShainKintaiKanri/src/main/resources/templates/home.html
+++ b/ShainKintaiKanri/src/main/resources/templates/home.html
@@ -106,7 +106,7 @@ a {
 					<td><a href="">もっと見る</a></td>
 				</tr>
 				<tbody id="noticeTableBody">
-					<tr th:each="notifications : ${notificationTitle}">
+					<tr th:each="notifications : ${importantNotificationTitle}">
 						<td><a class="input-width tall-row" id="title" th:text="${notifications.title}"></a></td>
 						<td class="button-cell"><button id="displayButton"
 								th:attr="data-id=${notifications.id}, data-start_time=${notifications.start_time}, data-end_time=${notifications.end_time}, data-status=${notifications.status}, data-title=${notifications.title}, data-content=${notifications.content}"
@@ -118,7 +118,7 @@ a {
 					<td><a href="">もっと見る</a></td>
 				</tr>
 				<tbody id="noticeTableBody">
-					<tr th:each="notifications : ${notificationTitle}">
+					<tr th:each="notifications : ${normalNotificationTitle}">
 						<td><a class="input-width tall-row" id="title" th:text="${notifications.title}"></a></td>
 						<td class="button-cell"><button id="displayButton"
 								th:attr="data-id=${notifications.id}, data-start_time=${notifications.start_time}, data-end_time=${notifications.end_time}, data-status=${notifications.status}, data-title=${notifications.title}, data-content=${notifications.content}"


### PR DESCRIPTION
# Jira Ticket
1．お知らせ表示件数を５件表示に修正
https://bss-portal.atlassian.net/browse/PORTAL-39
​2．お知らせを通常と重要に出し分け
https://bss-portal.atlassian.net/browse/PORTAL-40

# やった事
1．お知らせ表示件数を５件表示に修正
HomeController.java にお知らせ情報をDBから降順に取得し並び替え、5件分を取得するロジックを組んで、表示件数を制御しました。

​2．お知らせを通常と重要に出し分け
HomeController.java に通常と重要のリストを作成し、今まで行われていなかったStatusでの出し分けを行えるように修正しました。通常のお知らせは最新から5件表示し、重要のお知らせは全件表示しています。
​

# なぜやるのか
1．お知らせ表示件数を５件表示に修正
​お知らせデータを追加した分だけ表示されてしまう状態だったため。

​2．お知らせを通常と重要に出し分け
Homeページでは重要なお知らせとお知らせで項目が分かれているが、どちらにも同じ内容が表示されていたため。

​
# 動作確認
​windowsのEclipseで実行し、挙動確認を行いました。

1．お知らせ表示件数を５件表示に修正
【Home画面】
<img width="961" alt="スクリーンショット 2023-10-20 174142" src="https://github.com/miaochshBss/ShainKintaiKanriBss/assets/147013917/4fbe1f4d-7d4d-4da5-bee1-bfa977a2ca78">

​2．お知らせを通常と重要に出し分け
【Home画面】
<img width="960" alt="スクリーンショット 2023-10-23 130606" src="https://github.com/miaochshBss/ShainKintaiKanriBss/assets/147013917/fc5b2419-6921-483d-abe7-b91319a28186">

# Refs (レビューにあたって参考にすべき情報）(Optional)
Notificationsテーブルに仮データを30件登録しています。

レビュー、よろしくお願いいたします。


# 追加対応 (2023/10/23)
​2．お知らせを通常と重要に出し分け
Statusの分け出しロジックで、「0：重要」「1：通常」としていましたが、現状重要と通常しか存在しないため、
「0：重要」「else：その他(通常も含む)」となるようにロジックを修正しました。