### PR TITLE
実装機能：重要なお知らせ３か月以内のみ表示 (PORTAL-41)

### DIFF
--- a/ShainKintaiKanri/src/main/java/jp/co/bss/kintai/controller/HomeController.java
+++ b/ShainKintaiKanri/src/main/java/jp/co/bss/kintai/controller/HomeController.java
@@ -21,38 +21,41 @@ public class HomeController {
 	@Autowired
 	private HomeService homeService;
 
-    @GetMapping("/home")
-    public String home(HttpSession session, Model model) {
-        List<HomeInfo> notificationsData = homeService.getNotificationTitleInfoList();
+	@GetMapping("/home")
+	public String home(HttpSession session, Model model) {
+		List<HomeInfo> notificationsData = homeService.getNotificationTitleInfoList();
 
-        // 通常のお知らせと重要なお知らせを区別して抽出
-        List<HomeInfo> normalNotifications = new ArrayList<>();
-        List<HomeInfo> importantNotifications = new ArrayList<>();
+		// 通常のお知らせと重要なお知らせを区別して抽出
+		List<HomeInfo> normalNotifications = new ArrayList<>();
+		List<HomeInfo> importantNotifications = new ArrayList<>();
 
-        // 現在の日時を取得
-        LocalDate now = LocalDate.now();
+		// 現在の日時を取得
+		LocalDate now = LocalDate.now();
+		// 重要なお知らせの任意表示期間を設定 (本実装では3ヵ月)
+		LocalDate anyMonthAgo = now.minusMonths(3);
 
-        for (HomeInfo notificationTitle : notificationsData) {
-            if ("0".equals(notificationTitle.getStatus())) { // ステータス：0の場合は重要なお知らせ
-                LocalDate creationDate = notificationTitle.getCreation_date().toLocalDate();
-                // 3か月以内の通知のみを選別
-                if (now.minusMonths(3).isBefore(creationDate) || now.minusMonths(3).isEqual(creationDate)) {
-                    importantNotifications.add(notificationTitle);
-                }
-            } else { // ステータス：その他の場合は通常のお知らせ
-                normalNotifications.add(notificationTitle);
-            }
-        }
+		// 重要なお知らせと通常のお知らせの選別ロジック
+		for (HomeInfo notificationTitle : notificationsData) {
+			if ("0".equals(notificationTitle.getStatus())) { // ステータス：0の場合は重要なお知らせ
+				LocalDate creationDate = notificationTitle.getCreation_date().toLocalDate();
+				if (anyMonthAgo.isBefore(creationDate) || anyMonthAgo.isEqual(creationDate)) { // 任意の月以内の通知のみを選別
+					importantNotifications.add(notificationTitle);
+				}
+			} else { // ステータス：その他の場合は通常のお知らせ
+				normalNotifications.add(notificationTitle);
+			}
+		}
 
-        // 重要・通常お知らせのデータを降順に並べ替え
-        Collections.reverse(normalNotifications);
-        Collections.reverse(importantNotifications);
+		// 重要・通常お知らせのデータを降順に並べ替え
+		Collections.reverse(normalNotifications);
+		Collections.reverse(importantNotifications);
 
-        // 通常お知らせの最後から5件分を抽出
-        List<HomeInfo> lastFiveNormalNotificationsTitle = normalNotifications.subList(0, Math.min(5, normalNotifications.size()));
+		// 通常お知らせの最後から5件分を抽出
+		List<HomeInfo> lastFiveNormalNotificationsTitle = normalNotifications.subList(0,
+				Math.min(5, normalNotifications.size()));
 
-        model.addAttribute("normalNotificationTitle", lastFiveNormalNotificationsTitle);
-        model.addAttribute("importantNotificationTitle", importantNotifications);
-        return "home";
-    }
+		model.addAttribute("normalNotificationTitle", lastFiveNormalNotificationsTitle);
+		model.addAttribute("importantNotificationTitle", importantNotifications);
+		return "home";
+	}
 }

--- a/ShainKintaiKanri/src/main/java/jp/co/bss/kintai/controller/HomeController.java
+++ b/ShainKintaiKanri/src/main/java/jp/co/bss/kintai/controller/HomeController.java
@@ -1,5 +1,6 @@
 package jp.co.bss.kintai.controller;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -20,31 +21,38 @@ public class HomeController {
 	@Autowired
 	private HomeService homeService;
 
-	@GetMapping("/home")
-	public String home(HttpSession session, Model model) {
-		List<HomeInfo> notificationsData = homeService.getNotificationTitleInfoList();
+    @GetMapping("/home")
+    public String home(HttpSession session, Model model) {
+        List<HomeInfo> notificationsData = homeService.getNotificationTitleInfoList();
 
-		// 通常のお知らせと重要なお知らせを区別して抽出
-		List<HomeInfo> normalNotifications = new ArrayList<>();
-		List<HomeInfo> importantNotifications = new ArrayList<>();
-		for (HomeInfo notificationTitle : notificationsData) {
-			if ("0".equals(notificationTitle.getStatus())) { 	// ステータス：0の場合は重要なお知らせ
-				importantNotifications.add(notificationTitle);
-			} else { 											// ステータス：その他の場合は通常のお知らせ
-				normalNotifications.add(notificationTitle);
-			}
-		}
+        // 通常のお知らせと重要なお知らせを区別して抽出
+        List<HomeInfo> normalNotifications = new ArrayList<>();
+        List<HomeInfo> importantNotifications = new ArrayList<>();
 
-		// 重要・通常お知らせのデータを降順に並べ替え
-		Collections.reverse(normalNotifications);
-		Collections.reverse(importantNotifications);
+        // 現在の日時を取得
+        LocalDate now = LocalDate.now();
 
-		// 通常お知らせの最後から5件分を抽出
-		List<HomeInfo> lastFiveNormalNotificationsTitle = normalNotifications.subList(0,
-				Math.min(5, normalNotifications.size()));
+        for (HomeInfo notificationTitle : notificationsData) {
+            if ("0".equals(notificationTitle.getStatus())) { // ステータス：0の場合は重要なお知らせ
+                LocalDate creationDate = notificationTitle.getCreation_date().toLocalDate();
+                // 3か月以内の通知のみを選別
+                if (now.minusMonths(3).isBefore(creationDate) || now.minusMonths(3).isEqual(creationDate)) {
+                    importantNotifications.add(notificationTitle);
+                }
+            } else { // ステータス：その他の場合は通常のお知らせ
+                normalNotifications.add(notificationTitle);
+            }
+        }
 
-		model.addAttribute("normalNotificationTitle", lastFiveNormalNotificationsTitle);
-		model.addAttribute("importantNotificationTitle", importantNotifications);
-		return "home";
-	}
+        // 重要・通常お知らせのデータを降順に並べ替え
+        Collections.reverse(normalNotifications);
+        Collections.reverse(importantNotifications);
+
+        // 通常お知らせの最後から5件分を抽出
+        List<HomeInfo> lastFiveNormalNotificationsTitle = normalNotifications.subList(0, Math.min(5, normalNotifications.size()));
+
+        model.addAttribute("normalNotificationTitle", lastFiveNormalNotificationsTitle);
+        model.addAttribute("importantNotificationTitle", importantNotifications);
+        return "home";
+    }
 }


### PR DESCRIPTION
# Jira Ticket
1．重要なお知らせ３か月以内のみ表示
https://bss-portal.atlassian.net/browse/PORTAL-41


# やった事
1．重要なお知らせ３か月以内のみ表示
HomeController.java にHomeページに表示される**重要なお知らせ**のみ、3か月以内に登録されたものを表示するロジックを組みました。
​

# なぜやるのか
1．重要なお知らせ３か月以内のみ表示
現状だと重要なお知らせは登録された分だけ表示されてしまうため、こちらで指定した期間内に登録された重要なお知らせのみを表示する制御を行う必要があったため。(本実装では3か月)


# 動作確認
​windowsのEclipseで実行し、挙動確認を行いました。

重要なお知らせ３か月以内のみ表示
【Home画面】
<img width="768" alt="スクリーンショット 2023-10-23 163241" src="https://github.com/miaochshBss/ShainKintaiKanriBss/assets/147013917/e037cf91-ce69-4448-8424-cbaf895b8fd1">


# Refs (レビューにあたって参考にすべき情報）(Optional)
登録3か月以内の条件に引っかかるか検証するため、タイトル31というrowを追加しました。
元々のデータだと「タイトル16」が「creation_date　2023/08/14」のため、条件にマッチして表示されています。

レビュー、よろしくお願いいたします。

# 追加対応 (2023/10/23)
ソースの可読性、今後変更があった場合の変更しやすさを考え、ロジック内の「now.minusMonths(3);」を
「LocalDate anyMonthAgo = now.minusMonths(3);」という内容で変数化しました。