### PR TITLE
実装機能：お知らせ表示に日付追加 (PORTAL-44)

### DIFF
--- a/ShainKintaiKanri/src/main/resources/templates/home.html
+++ b/ShainKintaiKanri/src/main/resources/templates/home.html
@@ -34,7 +34,7 @@ body {
 
 .logo {
 	text-align: left;
-	margin-bottom: 20px;
+	margin-bottom: px;
 }
 
 .logo img {
@@ -54,7 +54,7 @@ table, th, td {
 }
 
 th, td {
-	padding: 10px;
+	padding: 8px;
 	text-align: left;
 }
 
@@ -91,6 +91,10 @@ a {
 	padding: 10px;
 	text-align: center;
 }
+
+.spacer {
+	padding: 5px;
+}
 </style>
 </head>
 <body>
@@ -107,22 +111,35 @@ a {
 				</tr>
 				<tbody id="noticeTableBody">
 					<tr th:each="notifications : ${importantNotificationTitle}">
-						<td><a class="input-width tall-row" id="title" th:text="${notifications.title}"></a></td>
-						<td class="button-cell"><button id="displayButton"
+						<td><a class="input-width tall-row" id="title"
+							th:text="${#dates.format(notifications.creation_date, 'yyyy/MM/dd') + '　　　' + notifications.title}"></a>
+						</td>
+						<td class="button-cell">
+							<button id="displayButton"
 								th:attr="data-id=${notifications.id}, data-start_time=${notifications.start_time}, data-end_time=${notifications.end_time}, data-status=${notifications.status}, data-title=${notifications.title}, data-content=${notifications.content}"
-								onclick="displayData(this)">表示</button></td>
+								onclick="displayData(this)">表示</button>
+						</td>
 					</tr>
 				</tbody>
+			</table>
+			
+			<div class="spacer"></div>
+
+			<table>
 				<tr>
 					<th>お知らせ</th>
 					<td><a href="">もっと見る</a></td>
 				</tr>
 				<tbody id="noticeTableBody">
 					<tr th:each="notifications : ${normalNotificationTitle}">
-						<td><a class="input-width tall-row" id="title" th:text="${notifications.title}"></a></td>
-						<td class="button-cell"><button id="displayButton"
+						<td><a class="input-width tall-row" id="title"
+							th:text="${#dates.format(notifications.creation_date, 'yyyy/MM/dd') + '　　　' + notifications.title}"></a>
+						</td>
+						<td class="button-cell">
+							<button id="displayButton"
 								th:attr="data-id=${notifications.id}, data-start_time=${notifications.start_time}, data-end_time=${notifications.end_time}, data-status=${notifications.status}, data-title=${notifications.title}, data-content=${notifications.content}"
-								onclick="displayData(this)">表示</button></td>
+								onclick="displayData(this)">表示</button>
+						</td>
 					</tr>
 				</tbody>
 			</table>
@@ -147,11 +164,6 @@ a {
 				<a href="/faq">社内FAQ</a>
 			</button>
 		</div>
-
-
-
 	</div>
-
-
 </body>
 </html>


### PR DESCRIPTION
# Jira Ticket
1．お知らせ表示に日付追加
https://bss-portal.atlassian.net/browse/PORTAL-44

# やった事
1．お知らせ表示に日付追加
home.html に日付 (登録日) が表示されるように修正しました。
軽微な変更ですが、重要なお知らせ枠とお知らせ枠の間にスペースを設けました。
​

# なぜやるのか
1．お知らせ表示に日付追加
現状だとタイトル表示しかされておらず、お知らせがいつ登録されたものかわからなかったため。


# 動作確認
​windowsのEclipseで実行し、挙動確認を行いました。

お知らせ表示に日付追加
【Home画面】
<img width="767" alt="スクリーンショット 2023-10-24 093520" src="https://github.com/miaochshBss/ShainKintaiKanriBss/assets/147013917/3e973ee7-49ac-48ac-b7c7-b0bdc4b04f96">


# Refs (レビューにあたって参考にすべき情報）(Optional)
現在表示されている日付は「creation_date」の日付です。

レビュー、よろしくお願いいたします。